### PR TITLE
Command formatting to be more robust, based on the arguments that IO.popen can accept

### DIFF
--- a/lib/guard/process.rb
+++ b/lib/guard/process.rb
@@ -6,8 +6,8 @@ module Guard
     def initialize(watchers = [], options = {})
       @process = nil
       @pid = nil
-      @command = options[:command]
-      @env = options[:env] 
+      @command = options.fetch(:command).split
+      @env = options[:env]
       @name = options[:name]
       @stop_signal = options[:stop_signal] || "TERM"
       super
@@ -23,7 +23,8 @@ module Guard
 
     def start
       UI.info("Starting process #{@name}")
-      @process = @env ? IO.popen([@env, @command]) : IO.popen(@command)
+      @command.unshift(@env) if @env
+      @process = IO.popen(@command)
       UI.info("Started process #{@name}")
       @pid = @process.pid
     end

--- a/test/guard/process_test.rb
+++ b/test/guard/process_test.rb
@@ -13,7 +13,7 @@ class GuardProcessTest < MiniTest::Unit::TestCase
     @guard.stop if @guard.process_running?
     ENV['GUARD_ENV'] = nil
   end
-  
+
   def test_run_all_returns_true
     assert @guard.run_all
   end
@@ -46,5 +46,21 @@ class GuardProcessTest < MiniTest::Unit::TestCase
     assert @guard.process_running?
     @guard.reload
     assert @guard.process_running?
+  end
+
+  def test_commands_are_formatted_correctly_with_and_without_env
+    @options = {:command => 'echo test test', :name => 'EchoProcess'}
+    @env     = {'VAR3' => 'VALUE 3'}
+
+    IO.expects(:popen).with(["echo", "test", "test"]).returns(stub_everything)
+    IO.expects(:popen).with([@env, "echo", "test", "test"]).returns(stub_everything)
+
+    @guard = Guard::Process.new([], @options)
+    @guard.start and @guard.stop
+
+    @options[:env] = @env
+
+    @guard = Guard::Process.new([], @options)
+    @guard.start and @guard.stop
   end
 end


### PR DESCRIPTION
Commands with spaces, such as "bundle exec rake resque:work" would fail due to the way the command was being passed into IO.popen. After looking through the IO.popen documentation it turns out it can be passed an array of commands, and also has the ability to take a hash as the environmental variables in the first position of that array. This fixes that issue, and the test suite is passing.

I've also changed the retrieval of the @command variable from the options hash to use .fetch. This will change the behavior so that, the initialize method will fail if the :command key does not exist on the options hash. The missing key exception is much more intuitive than an exception stating that .split was called on nil(which would be the case if the command was retrieved using the square brackets and it did not exist)
