### PR TITLE
Remove FFI

### DIFF
--- a/guard-process.gemspec
+++ b/guard-process.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('guard', '>= 0.4.2')
   s.add_dependency('spoon', '~> 0.0.1')
-  s.add_dependency('ffi', '~> 1.0.9')
   s.add_development_dependency('minitest')
   s.add_development_dependency('mocha')
   s.add_development_dependency('guard-minitest')


### PR DESCRIPTION
I had to remove the FFI requirement because of a version conflict with another gem.  Didn't seem to be used anyways - the tests pass, and guard-process seems to run correctly.
