### PR TITLE
Vagrantfile update

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant::Config.run do |config|
-  config.vm.box = "guard"
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.hostname = "guard"
+  config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
-  config.vm.network :hostonly, "192.168.33.21"
-  config.vm.share_folder "v-root", "/vagrant", ".", :nfs => !(ENV["OS"] =~ /windows/i)
+  config.vm.network :private_network, ip: "192.168.33.21"
   config.vm.provision :shell, :path => "vagrant-provision"
 end


### PR DESCRIPTION
This pull request updates the Vagrantfile to 2.x syntax. It also renames the box from "guard" to "precise64", this is a more standard name for the box and likely prevents the download of a Vagrant box specifically for guard-process for many developers.
