### PR TITLE
use guard-compat to fix broken tests

### DIFF
--- a/guard-process.gemspec
+++ b/guard-process.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('guard', '>= 2.0.0')
+  s.add_dependency('guard-compat', '~> 0.1', '>= 0.1.1')
   s.add_dependency('spoon', '~> 0.0.1')
   s.add_development_dependency('minitest')
   s.add_development_dependency('mocha')

--- a/lib/guard/process.rb
+++ b/lib/guard/process.rb
@@ -1,5 +1,4 @@
-require 'guard'
-require 'guard/plugin'
+require 'guard/compat/plugin'
 require 'spoon'
 
 module Guard

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,10 @@
 require 'minitest/autorun'
 require 'mocha/setup'
+
+require 'guard/notifier'
+require 'guard/compat/test/helper'
 require 'guard/process'
+
 require 'pry'
 
 TEST_ROOT = File.expand_path(File.dirname(__FILE__))


### PR DESCRIPTION
- uses guard-compat >= 0.1.1
- allows Guard::Notify to be used by guard-minitest for tests to run (Guard::Notify will be extracted to a separate gem at some point)
- 'guard/notify' should be included before 'guard/compat/test/helper', because of bad requires inside Guard 
- dependency on Guard >= 2.0.0 should be sufficient (other deps will be handled by guard-compat if necessary)
- `bundle exec rake test` now should work without issues
